### PR TITLE
AI09: fix image inference pretrained weight download

### DIFF
--- a/nutrihelp_ai/services/Food_Image_Classifier/scripts/model.py
+++ b/nutrihelp_ai/services/Food_Image_Classifier/scripts/model.py
@@ -3,9 +3,9 @@ import torch.nn as nn
 from torchvision.models import efficientnet_b0, EfficientNet_B0_Weights
 
 class FoodClassifier(nn.Module):
-    def __init__(self, num_classes=101):
+    def __init__(self, num_classes=101, use_pretrained=True):
         super(FoodClassifier, self).__init__()
-        weights = EfficientNet_B0_Weights.IMAGENET1K_V1
+        weights = EfficientNet_B0_Weights.IMAGENET1K_V1 if use_pretrained else None
         self.base_model = efficientnet_b0(weights=weights)
         in_features = self.base_model.classifier[1].in_features
         self.base_model.classifier = nn.Sequential(

--- a/nutrihelp_ai/services/Food_Image_Classifier/scripts/predict.py
+++ b/nutrihelp_ai/services/Food_Image_Classifier/scripts/predict.py
@@ -63,7 +63,10 @@ class Predictor:
             or checkpoint
         )
 
-        self.model = FoodClassifier(num_classes=len(self.class_names))
+        self.model = FoodClassifier(
+            num_classes=len(self.class_names),
+            use_pretrained=False,
+        )
         self.model.load_state_dict(model_state)
         self.model.to(self.device).eval()
         self.transform = build_eval_transform(


### PR DESCRIPTION
## Summary

This follow-up PR fixes the AI image analysis model loading issue found after the previous AI09 PR was merged.

Changes included:
- Added `use_pretrained` option to `FoodClassifier`.
- Updated inference path to use `use_pretrained=False`.
- Prevented the API from downloading EfficientNet pretrained weights at runtime.
- Ensured image analysis uses the local checkpoint only during inference.

## Why

The previous implementation worked on machines with cached Torch weights, but failed on fresh environments or unstable networks because inference still attempted to download pretrained EfficientNet weights.

## Testing

- Ran Python compile checks for `model.py` and `predict.py`.