### PR TITLE
AI09(c): reject non-food image scans

### DIFF
--- a/nutrihelp_ai/services/image_pipeline.py
+++ b/nutrihelp_ai/services/image_pipeline.py
@@ -11,8 +11,16 @@ from nutrihelp_ai.services.nutrition_lookup import NutritionLookupService
 logger = logging.getLogger(__name__)
 
 DEFAULT_TOPK = 5
-UNCLEAR_THRESHOLD = 0.60
-UNCLEAR_SUGGESTION = "Please upload a clearer, closer food image."
+# The classifier is closed-set: every image is forced into one of the known food
+# classes. Keep nutrition enrichment conservative so non-food or ambiguous images
+# do not look like confirmed meals.
+UNCLEAR_THRESHOLD = 0.80
+UNCLEAR_SUGGESTION = "Please upload a clearer food image or confirm the dish manually."
+UNCLEAR_NUTRITION_SOURCE = "withheld_unclear_prediction"
+REJECTED_SUGGESTION = (
+    "Please upload a clear food photo. The current image could not be validated as a food item."
+)
+REJECTED_NUTRITION_SOURCE = "withheld_rejected_image"
 
 
 class ImagePipelineService:
@@ -52,13 +60,22 @@ class ImagePipelineService:
         topk_items = list(prediction.get("topk", []))
         label = prediction.get("label")
         confidence = float(prediction.get("confidence", 0.0))
-        matches: List[Dict[str, Any]] = topk_items[:1] if label else []
 
-        quality_unclear = bool(quality.get("should_mark_unclear", False))
-        low_confidence = confidence < UNCLEAR_THRESHOLD
-        is_unclear = quality_unclear or low_confidence
+        prediction_rejected = bool(quality.get("should_reject_prediction", False))
+        public_label = None if prediction_rejected else label
+        public_confidence = 0.0 if prediction_rejected else confidence
+        public_topk = [] if prediction_rejected else topk_items
+        matches: List[Dict[str, Any]] = public_topk[:1] if public_label else []
+
+        quality_unclear = bool(quality.get("should_mark_unclear", False)) or not bool(
+            quality.get("passed", True)
+        )
+        low_confidence = False if prediction_rejected else confidence < UNCLEAR_THRESHOLD
+        is_unclear = prediction_rejected or quality_unclear or low_confidence
 
         reasons: List[str] = []
+        if prediction_rejected:
+            reasons.append("Image could not be validated as a clear food photo.")
         if low_confidence:
             reasons.append(
                 f"Top-1 confidence {confidence:.2f} below threshold {UNCLEAR_THRESHOLD:.2f}."
@@ -66,20 +83,33 @@ class ImagePipelineService:
         reasons.extend(quality.get("issues", []))
         unclear_reason = " ".join(reasons).strip()
 
-        nutrition = self.nutrition_lookup.lookup(label)
+        nutrition = (
+            self.nutrition_lookup.unavailable(
+                public_label,
+                source=REJECTED_NUTRITION_SOURCE
+                if prediction_rejected
+                else UNCLEAR_NUTRITION_SOURCE,
+            )
+            if is_unclear
+            else self.nutrition_lookup.lookup(public_label)
+        )
         recommendation = self.nutrition_lookup.build_recommendation(
             nutrition,
             is_unclear=is_unclear,
         )
 
         return {
-            "label": label,
-            "confidence": confidence,
+            "label": public_label,
+            "confidence": public_confidence,
             "matches": matches,
-            "topk": topk_items,
+            "topk": public_topk,
             "is_unclear": is_unclear,
             "unclear_reason": unclear_reason,
-            "suggestion": UNCLEAR_SUGGESTION if is_unclear else "",
+            "suggestion": REJECTED_SUGGESTION
+            if prediction_rejected
+            else UNCLEAR_SUGGESTION
+            if is_unclear
+            else "",
             "quality": self.quality_service.response_payload(quality),
             "error": None,
             "nutrition": nutrition,

--- a/nutrihelp_ai/services/image_quality.py
+++ b/nutrihelp_ai/services/image_quality.py
@@ -1,7 +1,13 @@
 from io import BytesIO
 from typing import Dict, List, Optional
 
+import numpy as np
 from PIL import Image, ImageFilter, ImageOps, ImageStat, UnidentifiedImageError
+
+try:
+    import cv2
+except Exception:  # pragma: no cover - OpenCV may be unavailable in minimal envs.
+    cv2 = None
 
 
 MIN_DIMENSION = 160
@@ -9,6 +15,7 @@ MIN_BRIGHTNESS = 35.0
 MAX_BRIGHTNESS = 235.0
 MIN_CONTRAST = 18.0
 MIN_SHARPNESS = 10.0
+MAX_FACE_AREA_RATIO = 0.08
 
 
 class InvalidImageError(ValueError):
@@ -16,6 +23,30 @@ class InvalidImageError(ValueError):
 
 
 class ImageQualityService:
+    def _contains_large_face(self, image: Image.Image) -> bool:
+        if cv2 is None:
+            return False
+
+        cascade_path = getattr(cv2.data, "haarcascades", "") + "haarcascade_frontalface_default.xml"
+        classifier = cv2.CascadeClassifier(cascade_path)
+        if classifier.empty():
+            return False
+
+        rgb = np.array(image)
+        gray = cv2.cvtColor(rgb, cv2.COLOR_RGB2GRAY)
+        faces = classifier.detectMultiScale(
+            gray,
+            scaleFactor=1.1,
+            minNeighbors=5,
+            minSize=(60, 60),
+        )
+        if len(faces) == 0:
+            return False
+
+        image_area = max(1, image.size[0] * image.size[1])
+        largest_face_area = max(int(width) * int(height) for _, _, width, height in faces)
+        return (largest_face_area / image_area) >= MAX_FACE_AREA_RATIO
+
     def analyze(self, image_bytes: bytes) -> Dict[str, object]:
         if not image_bytes:
             raise InvalidImageError("Uploaded file is empty.")
@@ -32,6 +63,7 @@ class ImageQualityService:
         contrast = round(float(ImageStat.Stat(gray).stddev[0]), 2)
         edges = gray.filter(ImageFilter.FIND_EDGES)
         sharpness = round(float(ImageStat.Stat(edges).mean[0]), 2)
+        contains_large_face = self._contains_large_face(image)
 
         issues: List[str] = []
         if min(width, height) < MIN_DIMENSION:
@@ -44,12 +76,16 @@ class ImageQualityService:
             issues.append("Image has low contrast.")
         if sharpness < MIN_SHARPNESS:
             issues.append("Image appears blurry.")
+        if contains_large_face:
+            issues.append("Image appears to contain a large face. Please upload a clear food photo.")
 
         should_mark_unclear = (
             min(width, height) < MIN_DIMENSION
             or sharpness < MIN_SHARPNESS
+            or contains_large_face
             or len(issues) >= 2
         )
+        passed = len(issues) == 0
 
         return {
             "width": width,
@@ -57,9 +93,10 @@ class ImageQualityService:
             "brightness": brightness,
             "contrast": contrast,
             "sharpness": sharpness,
-            "passed": len(issues) == 0,
+            "passed": passed,
             "issues": issues,
             "should_mark_unclear": should_mark_unclear,
+            "should_reject_prediction": not passed,
         }
 
     def response_payload(self, analysis: Dict[str, object]) -> Dict[str, object]:

--- a/nutrihelp_ai/services/nutrition_lookup.py
+++ b/nutrihelp_ai/services/nutrition_lookup.py
@@ -355,6 +355,11 @@ LABEL_ALIASES = {
 
 
 class NutritionLookupService:
+    def unavailable(self, label: Optional[str] = None, *, source: str = "unavailable") -> Dict[str, object]:
+        nutrition = self._unavailable(label=label)
+        nutrition["source"] = source
+        return nutrition
+
     def lookup(self, label: Optional[str]) -> Dict[str, object]:
         if not label:
             return self._unavailable()


### PR DESCRIPTION
## Changes
- Reject unclear/non-food-like image scans before exposing a confirmed food label.
- Withhold top-k, confidence, and nutrition when the uploaded image fails validation.
- Return `nutrition.available=false` and `estimated_calories=null` for rejected scans.
- Added a face-heavy image check to avoid classifying user/person photos as food.
- Kept normal food-photo scans working with the existing nutrition lookup.

## Why
The current classifier is a closed-set Food-101 model, so any uploaded image can be forced into one of the known food classes. This caused non-food images, such as person photos, to be classified as dishes and receive calorie estimates.

## Testing
- Ran Python compile checks for updated AI services.
- Manually tested valid food images and non-food/person images through the scan flow.
- Confirmed rejected scans no longer expose a confirmed label or calorie estimate.