### PR TITLE
AI09d: relax scan quality gate

### DIFF
--- a/nutrihelp_ai/services/image_pipeline.py
+++ b/nutrihelp_ai/services/image_pipeline.py
@@ -67,9 +67,7 @@ class ImagePipelineService:
         public_topk = [] if prediction_rejected else topk_items
         matches: List[Dict[str, Any]] = public_topk[:1] if public_label else []
 
-        quality_unclear = bool(quality.get("should_mark_unclear", False)) or not bool(
-            quality.get("passed", True)
-        )
+        quality_unclear = bool(quality.get("should_mark_unclear", False))
         low_confidence = False if prediction_rejected else confidence < UNCLEAR_THRESHOLD
         is_unclear = prediction_rejected or quality_unclear or low_confidence
 

--- a/nutrihelp_ai/services/image_quality.py
+++ b/nutrihelp_ai/services/image_quality.py
@@ -79,13 +79,11 @@ class ImageQualityService:
         if contains_large_face:
             issues.append("Image appears to contain a large face. Please upload a clear food photo.")
 
-        should_mark_unclear = (
+        blocking_quality_issue = (
             min(width, height) < MIN_DIMENSION
             or sharpness < MIN_SHARPNESS
             or contains_large_face
-            or len(issues) >= 2
         )
-        passed = len(issues) == 0
 
         return {
             "width": width,
@@ -93,10 +91,10 @@ class ImageQualityService:
             "brightness": brightness,
             "contrast": contrast,
             "sharpness": sharpness,
-            "passed": passed,
+            "passed": not blocking_quality_issue,
             "issues": issues,
-            "should_mark_unclear": should_mark_unclear,
-            "should_reject_prediction": not passed,
+            "should_mark_unclear": blocking_quality_issue,
+            "should_reject_prediction": contains_large_face,
         }
 
     def response_payload(self, analysis: Dict[str, object]) -> Dict[str, object]:


### PR DESCRIPTION
## Summary
This follow-up PR relaxes the image scan quality gate so valid food photos with minor visual warnings are not rejected too aggressively.

## Changes
- Do not reject food predictions only because of brightness or contrast warnings.
- Keep blocking quality checks for clearly problematic images such as very low resolution, blurry images, or large face/person photos.
- Only fully reject prediction output when the image appears to contain a large face/non-food subject.
- Keep low-confidence food predictions in the review flow instead of treating them as hard failures.

## Why
Some valid food images, such as hotdog or dessert photos on bright/white backgrounds, were being marked as unclear or rejected even when the food was visible. This made the scan flow feel broken for acceptable food images.

## Testing
- Ran Python compile checks for updated AI services.
- Tested simulated food images with brightness/contrast warnings.
- Confirmed food images can still return labels/calories when confidence is high.
- Confirmed low-confidence cases still require review.
- Confirmed face/person images are still rejected.