### PR TITLE
AI012: Improve chat_with_rag retrieval and domain-safe fallback (Nutrihelp_AI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ CHROMA_TENANT=
 CHROMA_DATABASE=
 CHROMA_PATH=./.chroma
 RAG_COLLECTION=aus_food_nutrition
+RAG_N_RESULTS=5
+RAG_DISTANCE_THRESHOLD=0.8
+RAG_RELAXED_DISTANCE_THRESHOLD=1.6
 
 # Optional legacy override
 # Leave unset for the active runtime.

--- a/2025-T2/document-parser/rebuild_chroma_collection.py
+++ b/2025-T2/document-parser/rebuild_chroma_collection.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import logging
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import chromadb
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from nutrihelp_ai.services.active_ai_backend import ActiveAISettings, _load_project_env
+
+logger = logging.getLogger("rebuild_chroma_collection")
+
+ALLOW_PREFIXES = [
+    "https://www.health.gov.au/topics/food-and-nutrition",
+    "https://www.foodstandards.gov.au/consumer/nutrition",
+    "https://www.foodstandards.gov.au/consumer/labelling/nutrition",
+    "https://www.foodstandards.gov.au/consumer/labelling/panels",
+    "https://www.foodstandards.gov.au/consumer/food-fortification",
+    "https://www.foodstandards.gov.au/science-data/food-nutrient-databases/afcd",
+    "https://www.foodstandards.gov.au/science-data/food-nutrient-databases/ausnut/food-nutrients",
+    "https://www.abs.gov.au/statistics/health/health-conditions-and-risks/australian-health-survey-nutrition-first-results-foods-and-nutrients",
+    "https://www.abs.gov.au/statistics/health/health-conditions-and-risks/apparent-consumption-selected-foodstuffs-australia",
+    "https://www.abs.gov.au/statistics/health/health-conditions-and-risks/national-health-measures-survey",
+]
+
+EXCLUDE_TITLE_TERMS = [
+    "legal information",
+    "data files",
+    "frequently asked questions (afcd)",
+    "resources",
+    "homepage",
+    "privacy",
+    "food recalls",
+    "food regulatory agencies",
+]
+
+BOILERPLATE_SUBSTRINGS = [
+    "skip to main content",
+    "listen print share",
+    "funding find funding",
+    "contact us",
+    "download table as csv",
+    "download graph as",
+    "related resources companion resources",
+    "annual compliance report",
+    "temporary employment register",
+    "food and nutrition topics food and nutrition",
+    "nutrition | food standards australia new zealand skip to main content",
+]
+
+UTILITY_TERMS = [
+    "nutrition",
+    "nutrient",
+    "healthy",
+    "food group",
+    "serve",
+    "calcium",
+    "iron",
+    "protein",
+    "vitamin",
+    "mineral",
+    "dairy",
+    "legumes",
+    "beans",
+    "wholegrain",
+    "fruit",
+    "vegetable",
+    "milk",
+    "yoghurt",
+    "cheese",
+    "tofu",
+    "fish",
+    "meat",
+    "eggs",
+    "sardines",
+    "diet",
+    "kilojoules",
+    "iodine",
+    "folate",
+    "magnesium",
+    "sodium",
+    "fat",
+    "sugar",
+]
+
+TIME_PREFIX_RE = re.compile(r"^\d{2}:\d{2}\s")
+
+
+def build_chroma_client(settings: ActiveAISettings):
+    if settings.chroma_mode.lower() == "cloud":
+        return chromadb.CloudClient(
+            tenant=settings.chroma_tenant,
+            database=settings.chroma_database,
+            api_key=settings.chroma_api_key,
+        )
+    return chromadb.PersistentClient(path=settings.chroma_path)
+
+
+def iter_records(path: Path) -> Iterable[Dict[str, str]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                yield json.loads(line)
+
+
+def sentence_is_useful(record: Dict[str, str]) -> bool:
+    source_url = record.get("source_url", "").lower()
+    title = record.get("title", "").lower()
+    sentence = " ".join(record.get("sentence", "").split())
+    lowered = sentence.lower()
+
+    if not any(source_url.startswith(prefix) for prefix in ALLOW_PREFIXES):
+        return False
+    if any(term in title for term in EXCLUDE_TITLE_TERMS):
+        return False
+    if TIME_PREFIX_RE.match(sentence):
+        return False
+    if any(term in lowered for term in BOILERPLATE_SUBSTRINGS):
+        return False
+    if len(sentence) < 40 or len(sentence) > 500:
+        return False
+    if not any(term in lowered for term in UTILITY_TERMS):
+        return False
+    return True
+
+
+def build_documents(
+    sentences_path: Path,
+    max_sentences_per_chunk: int = 5,
+    max_chars_per_chunk: int = 1200,
+) -> Tuple[List[str], List[Dict[str, object]], Dict[str, int]]:
+    grouped: Dict[Tuple[str, str, Optional[str]], List[Dict[str, str]]] = defaultdict(list)
+
+    for record in iter_records(sentences_path):
+        if not sentence_is_useful(record):
+            continue
+        key = (
+            record.get("title", "").strip(),
+            record.get("source_url", "").strip(),
+            record.get("doc_path"),
+        )
+        grouped[key].append(record)
+
+    documents: List[str] = []
+    metadatas: List[Dict[str, object]] = []
+
+    for (title, source_url, doc_path), records in grouped.items():
+        unique_sentences: List[str] = []
+        seen_sentences = set()
+        for record in records:
+            sentence = " ".join(record.get("sentence", "").split())
+            normalized = sentence.lower()
+            if normalized in seen_sentences:
+                continue
+            seen_sentences.add(normalized)
+            unique_sentences.append(sentence)
+
+        chunk: List[str] = []
+        chunk_len = 0
+        chunk_index = 0
+
+        for sentence in unique_sentences:
+            additional = len(sentence) + 1
+            if chunk and (
+                len(chunk) >= max_sentences_per_chunk
+                or chunk_len + additional > max_chars_per_chunk
+            ):
+                documents.append(
+                    f"Title: {title}\nSource: {source_url}\n\n"
+                    + " ".join(chunk)
+                )
+                metadatas.append(
+                    {
+                        "source_url": source_url,
+                        "title": title,
+                        "doc_path": doc_path or "",
+                        "chunk_index": chunk_index,
+                        "sentence_count": len(chunk),
+                    }
+                )
+                chunk = []
+                chunk_len = 0
+                chunk_index += 1
+
+            chunk.append(sentence)
+            chunk_len += additional
+
+        if chunk:
+            documents.append(
+                f"Title: {title}\nSource: {source_url}\n\n"
+                + " ".join(chunk)
+            )
+            metadatas.append(
+                {
+                    "source_url": source_url,
+                    "title": title,
+                    "doc_path": doc_path or "",
+                    "chunk_index": chunk_index,
+                    "sentence_count": len(chunk),
+                }
+            )
+
+    stats = {
+        "documents": len(documents),
+        "sources": len(grouped),
+    }
+    return documents, metadatas, stats
+
+
+def backup_existing_collection(collection, backup_path: Path) -> int:
+    count = collection.count()
+    if count == 0:
+        return 0
+
+    payload = collection.get(include=["documents", "metadatas"])
+    ids = payload.get("ids", [])
+    documents = payload.get("documents", [])
+    metadatas = payload.get("metadatas", [])
+
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    with backup_path.open("w", encoding="utf-8") as handle:
+        for idx, doc_id in enumerate(ids):
+            record = {
+                "id": doc_id,
+                "document": documents[idx] if idx < len(documents) else "",
+                "metadata": metadatas[idx] if idx < len(metadatas) else {},
+            }
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    return count
+
+
+def rebuild_collection(
+    client,
+    collection_name: str,
+    documents: List[str],
+    metadatas: List[Dict[str, object]],
+    backup_dir: Path,
+    batch_size: int = 100,
+) -> Dict[str, int]:
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = backup_dir / f"{collection_name}_backup.jsonl"
+
+    try:
+        existing = client.get_collection(name=collection_name)
+        backed_up = backup_existing_collection(existing, backup_path)
+        client.delete_collection(name=collection_name)
+    except Exception:
+        backed_up = 0
+
+    collection = client.get_or_create_collection(name=collection_name)
+    inserted = 0
+
+    for start in range(0, len(documents), batch_size):
+        docs_batch = documents[start : start + batch_size]
+        metadata_batch = metadatas[start : start + batch_size]
+        ids_batch = []
+        for offset, (doc, metadata) in enumerate(zip(docs_batch, metadata_batch), start=start):
+            raw_id = f"{metadata.get('source_url','')}|{metadata.get('chunk_index',0)}|{offset}"
+            ids_batch.append(hashlib.sha1(raw_id.encode("utf-8")).hexdigest())
+        collection.upsert(ids=ids_batch, documents=docs_batch, metadatas=metadata_batch)
+        inserted += len(docs_batch)
+
+    return {
+        "backed_up": backed_up,
+        "inserted": inserted,
+        "final_count": collection.count(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Clean and rebuild the aus_food_nutrition Chroma collection.")
+    parser.add_argument(
+        "--sentences",
+        default="2025-T2/document-parser/data/sentences.jsonl",
+        help="Path to the source JSONL sentences file.",
+    )
+    parser.add_argument(
+        "--collection",
+        default=None,
+        help="Override Chroma collection name. Defaults to RAG_COLLECTION from env.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only print the filtered ingest summary without modifying Chroma.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Batch size for Chroma upserts.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    _load_project_env()
+    settings = ActiveAISettings()
+
+    sentences_path = Path(args.sentences).resolve()
+    if not sentences_path.is_file():
+        raise SystemExit(f"Sentences file not found: {sentences_path}")
+
+    documents, metadatas, stats = build_documents(sentences_path)
+    logger.info(
+        "Prepared filtered nutrition corpus from %s (sources=%s chunks=%s)",
+        sentences_path,
+        stats["sources"],
+        stats["documents"],
+    )
+
+    if args.dry_run:
+        sample_count = min(3, len(documents))
+        for idx in range(sample_count):
+            logger.info("Sample chunk %s metadata=%s", idx + 1, metadatas[idx])
+            logger.info("%s", documents[idx][:500])
+        return 0
+
+    client = build_chroma_client(settings)
+    collection_name = args.collection or settings.rag_collection
+    result = rebuild_collection(
+        client=client,
+        collection_name=collection_name,
+        documents=documents,
+        metadatas=metadatas,
+        backup_dir=Path("2025-T2/document-parser/data/backups").resolve(),
+        batch_size=args.batch_size,
+    )
+    logger.info(
+        "Rebuilt collection %s (backed_up=%s inserted=%s final_count=%s)",
+        collection_name,
+        result["backed_up"],
+        result["inserted"],
+        result["final_count"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nutrihelp_ai/services/active_ai_backend.py
+++ b/nutrihelp_ai/services/active_ai_backend.py
@@ -76,6 +76,17 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid integer value for %s=%r; falling back to %s", name, raw, default)
+        return default
+
+
 @dataclass(frozen=True)
 class ActiveAISettings:
     groq_api_key: str = field(default_factory=lambda: os.getenv("GROQ_API_KEY", ""))
@@ -86,6 +97,9 @@ class ActiveAISettings:
     chroma_tenant: str = field(default_factory=lambda: os.getenv("CHROMA_TENANT", ""))
     chroma_database: str = field(default_factory=lambda: os.getenv("CHROMA_DATABASE", ""))
     rag_collection: str = field(default_factory=lambda: os.getenv("RAG_COLLECTION", "aus_food_nutrition"))
+    rag_n_results: int = field(default_factory=lambda: _env_int("RAG_N_RESULTS", 5))
+    rag_distance_threshold: float = field(default_factory=lambda: _env_float("RAG_DISTANCE_THRESHOLD", 0.8))
+    rag_relaxed_distance_threshold: float = field(default_factory=lambda: _env_float("RAG_RELAXED_DISTANCE_THRESHOLD", 1.6))
     groq_temperature: float = field(default_factory=lambda: _env_float("GROQ_TEMPERATURE", 0.0))
     groq_top_p: float = field(default_factory=lambda: _env_float("GROQ_TOP_P", 1.0))
 
@@ -121,6 +135,16 @@ GROUNDING_SYSTEM_PROMPT = (
     "6) If the context is insufficient, reply exactly: 'I don\'t have enough information on that topic in my knowledge base.'"
 )
 
+DOMAIN_CHAT_SYSTEM_PROMPT = (
+    "You are NutriBot, the NutriHelp assistant.\n"
+    "You only help with nutrition, meals, food choices, healthy eating, calorie guidance, nutrients, "
+    "dietary habits, food scanning follow-up, and user health goals related to diet and lifestyle.\n"
+    "If the user asks something outside that scope, do not answer it as a general-purpose assistant. "
+    "Instead, briefly explain that you focus on nutrition, meals, and healthy eating, then invite the user "
+    "to ask a food or nutrition question.\n"
+    "Keep replies concise, practical, and friendly."
+)
+
 
 class GroqChromaBackend:
     def __init__(
@@ -141,6 +165,78 @@ class GroqChromaBackend:
         if not Groq:
             return "groq package not installed/importable"
         return "unknown client initialization issue"
+
+    def _domain_redirect_reply(self) -> str:
+        return (
+            "I'm here to help with nutrition, meals, healthy eating, and your food-related health goals. "
+            "Try asking about foods, calories, nutrients, meal ideas, or diet guidance."
+        )
+
+    def _is_social_prompt(self, prompt: str) -> bool:
+        clean = (prompt or "").strip().lower()
+        if not clean:
+            return False
+        social_patterns = [
+            r"^(hi|hello|hey|good morning|good afternoon|good evening)\b",
+            r"^(thanks|thank you|thx)\b",
+            r"^(how are you|how are you doing)\b",
+        ]
+        return any(re.search(pattern, clean) for pattern in social_patterns)
+
+    def _is_nutrition_domain_prompt(self, prompt: str) -> bool:
+        clean = (prompt or "").strip().lower()
+        if not clean:
+            return False
+
+        nutrition_keywords = [
+            "nutrition",
+            "nutrient",
+            "calorie",
+            "protein",
+            "carb",
+            "fat",
+            "fibre",
+            "fiber",
+            "vitamin",
+            "mineral",
+            "iron",
+            "calcium",
+            "sodium",
+            "cholesterol",
+            "food",
+            "meal",
+            "diet",
+            "healthy eating",
+            "weight loss",
+            "weight gain",
+            "breakfast",
+            "lunch",
+            "dinner",
+            "snack",
+            "recipe",
+            "ingredient",
+            "serving",
+            "portion",
+            "scan",
+            "dish",
+            "older adults",
+            "seniors",
+            "exercise",
+            "gym",
+            "hydration",
+            "water",
+            "diabetes",
+            "blood pressure",
+        ]
+        return any(keyword in clean for keyword in nutrition_keywords)
+
+    def _chat_with_domain_guard(self, prompt: str, model: Optional[str] = None) -> str:
+        if self._is_social_prompt(prompt):
+            return self.chat(prompt, model=model, system_prompt=DOMAIN_CHAT_SYSTEM_PROMPT)
+        if not self._is_nutrition_domain_prompt(prompt):
+            logger.info("Domain guard redirected out-of-scope prompt")
+            return self._domain_redirect_reply()
+        return self.chat(prompt, model=model, system_prompt=DOMAIN_CHAT_SYSTEM_PROMPT)
 
     def _get_groq_client(self):
         if self._groq_client is not None:
@@ -304,10 +400,10 @@ class GroqChromaBackend:
             return _safe_reply()
 
     def run_agent(self, prompt: str, model: Optional[str] = None) -> str:
-        return self.chat(prompt, model=model)
+        return self._chat_with_domain_guard(prompt, model=model)
 
     async def run_agent_ws(self, prompt: str, model: Optional[str] = None) -> str:
-        return self.chat(prompt, model=model)
+        return self._chat_with_domain_guard(prompt, model=model)
 
     def retrieve(self, query: str, n_results: int = 4) -> List[str]:
         collection = self._get_collection()
@@ -323,22 +419,133 @@ class GroqChromaBackend:
             logger.error("Chroma query failed: %s", exc)
             return []
 
-    def retrieve_with_threshold(self, query: str, n_results: int = 5, distance_threshold: float = 0.8) -> List[str]:
+    def retrieve_ranked(self, query: str, n_results: Optional[int] = None) -> List[tuple[str, float]]:
         collection = self._get_collection()
         if collection is None:
             return []
 
+        limit = n_results or self.settings.rag_n_results
+        fetch_limit = max(limit, limit * 3)
+
         try:
             if self.collection_count() == 0:
                 return []
-            result = collection.query(query_texts=[query], n_results=n_results)
+            result = collection.query(query_texts=[query], n_results=fetch_limit)
             documents = result.get("documents", [[]])[0]
             distances = result.get("distances", [[]])[0]
         except Exception as exc:
-            logger.error("Chroma threshold query failed: %s", exc)
+            logger.error("Chroma ranked query failed: %s", exc)
             return []
 
-        return [document for document, distance in zip(documents, distances) if distance <= distance_threshold]
+        ranked: List[tuple[str, float]] = []
+        seen_documents = set()
+        for document, distance in zip(documents, distances):
+            if not document or distance is None:
+                continue
+            normalized = " ".join(document.split()).strip().lower()
+            if normalized in seen_documents:
+                continue
+            seen_documents.add(normalized)
+            ranked.append((document, float(distance)))
+            if len(ranked) >= limit:
+                break
+
+        distance_summary = [round(distance, 3) for _, distance in ranked]
+        query_preview = query.replace("\n", " ").strip()[:80]
+        logger.info(
+            "RAG retrieval summary (collection=%s query=%r candidates=%s distances=%s)",
+            self.collection_name,
+            query_preview,
+            len(ranked),
+            distance_summary,
+        )
+        return ranked
+
+    def _looks_like_meta_context(self, document: str) -> bool:
+        lowered = document.lower()
+        meta_markers = [
+            "structured prompting approach",
+            "content-type: application/json",
+            "json body",
+            "example successful response",
+            "the recipe engine does not work directly",
+            "langchain",
+            "redis memory",
+            "serp",
+            "openai models",
+        ]
+        return any(marker in lowered for marker in meta_markers)
+
+    def retrieve_with_threshold(self, query: str, n_results: int = 5, distance_threshold: float = 0.8) -> List[str]:
+        ranked = self.retrieve_ranked(query=query, n_results=n_results)
+        return [document for document, distance in ranked if distance <= distance_threshold]
+
+    def retrieve_for_rag(
+        self,
+        query: str,
+        n_results: Optional[int] = None,
+        distance_threshold: Optional[float] = None,
+        relaxed_distance_threshold: Optional[float] = None,
+    ) -> List[str]:
+        limit = n_results or self.settings.rag_n_results
+        strict_threshold = (
+            self.settings.rag_distance_threshold
+            if distance_threshold is None
+            else distance_threshold
+        )
+        relaxed_threshold = (
+            self.settings.rag_relaxed_distance_threshold
+            if relaxed_distance_threshold is None
+            else relaxed_distance_threshold
+        )
+
+        if relaxed_threshold < strict_threshold:
+            relaxed_threshold = strict_threshold
+
+        ranked = self.retrieve_ranked(query=query, n_results=limit)
+        if not ranked:
+            return []
+
+        filtered_ranked = [
+            (document, distance)
+            for document, distance in ranked
+            if not self._looks_like_meta_context(document)
+        ]
+        if len(filtered_ranked) != len(ranked):
+            logger.info(
+                "RAG retrieval filtered low-value contexts=%s",
+                len(ranked) - len(filtered_ranked),
+            )
+        ranked = filtered_ranked
+        if not ranked:
+            logger.info("RAG retrieval produced only filtered meta-contexts; treating as no context")
+            return []
+
+        strict_contexts = [document for document, distance in ranked if distance <= strict_threshold]
+        if strict_contexts:
+            logger.info(
+                "RAG retrieval accepted strict contexts=%s threshold=%.2f",
+                len(strict_contexts),
+                strict_threshold,
+            )
+            return strict_contexts
+
+        relaxed_contexts = [document for document, distance in ranked if distance <= relaxed_threshold]
+        if relaxed_contexts:
+            logger.info(
+                "RAG retrieval accepted relaxed contexts=%s strict=%.2f relaxed=%.2f",
+                len(relaxed_contexts),
+                strict_threshold,
+                relaxed_threshold,
+            )
+            return relaxed_contexts
+
+        logger.info(
+            "RAG retrieval found no contexts within strict=%.2f or relaxed=%.2f",
+            strict_threshold,
+            relaxed_threshold,
+        )
+        return []
 
     def _build_grounded_user_prompt(self, contexts: List[str], question: str) -> str:
         joined_context = "\n\n".join(contexts)
@@ -351,16 +558,17 @@ class GroqChromaBackend:
     def generate_with_rag(
         self,
         prompt: str,
-        n_results: int = 5,
+        n_results: Optional[int] = None,
         model: Optional[str] = None,
-        distance_threshold: float = 0.8,
+        distance_threshold: Optional[float] = None,
+        relaxed_distance_threshold: Optional[float] = None,
     ) -> str:
-        contexts = self.retrieve_with_threshold(
+        contexts = self.retrieve_for_rag(
             query=prompt,
             n_results=n_results,
             distance_threshold=distance_threshold,
+            relaxed_distance_threshold=relaxed_distance_threshold,
         )
-        # AI04: Fallback when Chroma returns no useful context
         if not contexts:
             logger.warning("RAG fallback triggered - no relevant context found for: %s", prompt)
             return (
@@ -409,17 +617,23 @@ class GroqChromaBackend:
     def chat_with_rag_fallback(self, prompt: str, model: Optional[str] = None) -> str:
         logger.info("AI07 chat_with_rag_fallback called (prompt_len=%s)", len(prompt or ""))
         try:
-            contexts = self.retrieve_with_threshold(
+            contexts = self.retrieve_for_rag(
                 query=prompt,
-                n_results=5,
-                distance_threshold=0.8,
+                n_results=self.settings.rag_n_results,
+                distance_threshold=self.settings.rag_distance_threshold,
+                relaxed_distance_threshold=self.settings.rag_relaxed_distance_threshold,
             )
-            logger.info("AI07 retrieval complete (contexts=%s)", len(contexts))
+            logger.info(
+                "AI07 retrieval complete (contexts=%s strict=%.2f relaxed=%.2f)",
+                len(contexts),
+                self.settings.rag_distance_threshold,
+                self.settings.rag_relaxed_distance_threshold,
+            )
 
             # AI07 step 1: no contexts -> fallback to regular chat
             if not contexts:
                 logger.info("AI07 fallback to chat (no RAG context)")
-                return self.chat(prompt, model=model)
+                return self._chat_with_domain_guard(prompt, model=model)
 
             # AI07 step 2: generate RAG answer when contexts exist
             grounded_prompt = self._build_grounded_user_prompt(contexts, prompt)
@@ -433,7 +647,7 @@ class GroqChromaBackend:
             # AI07 step 3: weak RAG response -> fallback to regular chat
             if self._is_weak_rag_response(rag_response):
                 logger.info("AI07 fallback to chat (weak RAG response)")
-                fallback = self.chat(prompt, model=model)
+                fallback = self._chat_with_domain_guard(prompt, model=model)
                 if fallback == _safe_reply():
                     logger.error("AI07 fallback chat also unavailable. Root issue likely: %s", self._chat_unavailable_reason())
                 return fallback
@@ -441,7 +655,7 @@ class GroqChromaBackend:
             return rag_response
         except Exception:
             logger.exception("AI07 RAG fallback pipeline failed, using chat fallback")
-            return self.chat(prompt, model=model)
+            return self._chat_with_domain_guard(prompt, model=model)
 
     def add_documents(self, docs: List[str]) -> int:
         collection = self._get_collection()


### PR DESCRIPTION
Summary
This PR improves the production chatbot backend by strengthening raw RAG retrieval quality and keeping fallback responses within the NutriHelp nutrition domain.

Changes made
- improved ranked RAG retrieval and context filtering
- added relaxed retrieval threshold support
- filtered low-value meta/prompt-guide contexts from RAG results
- added a rebuild script for the nutrition Chroma collection
- kept `/chat` as the smart production route
- added domain-safe fallback so out-of-scope prompts are redirected instead of answered as general chat

Tested
- `/chat_with_rag` now returns grounded answers for nutrition questions such as calcium and iron
- `/chat` still works as the production smart route
- off-topic prompts such as “Tell me a joke” are redirected back to the NutriHelp domain
