### PR TITLE
AI017-Allow profile-enriched chatbot prompts

### DIFF
--- a/nutrihelp_ai/routers/chatbot_api.py
+++ b/nutrihelp_ai/routers/chatbot_api.py
@@ -13,9 +13,9 @@ class ChatRequest(BaseModel):
     query: str = Field(
         ...,
         min_length=1,
-        max_length=2000,           
+        max_length=6000,
         strip_whitespace=True,
-        description="User's chat message or question"
+        description="User's chat message or question, optionally enriched with trusted app profile context"
     )
 
 class ChatResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Routes chatbot requests through the app API so logged-in user profile and preference data can be used before calling the AI backend.
- Adds a chatbot greeting endpoint that can greet the user by saved profile name.
- Injects dietary requirements, allergies/intolerances, preferred cuisines, disliked ingredients, health conditions, spice level, and cooking methods into nutrition-related chatbot prompts.
- Keeps non-nutrition prompts on the existing domain guard/fallback path.
- Adds safety-note prompting for allergy, medical condition, and health-risk related responses.
- Expands the AI chatbot request limit so profile-enriched prompts are accepted.

## Testing
- `node --check services/chatbotService.js`
- `node --check controller/chatbotController.js`
- `node --check services/index.js`
- `python -m py_compile nutrihelp_ai/routers/chatbot_api.py`
- Manual chatbot checks for nutrition, allergy/gluten, meal recommendation, and non-nutrition fallback prompts.
