### PR TITLE
AI018 improve scan image reliability

### DIFF
--- a/nutrihelp_ai/services/image_pipeline.py
+++ b/nutrihelp_ai/services/image_pipeline.py
@@ -15,9 +15,10 @@ DEFAULT_TOPK = 5
 # The classifier is closed-set: every image is forced into one of the known food
 # classes. Keep nutrition enrichment conservative so non-food or ambiguous images
 # do not look like confirmed meals.
-CONFIRMATION_THRESHOLD = 0.99
+CONFIRMATION_THRESHOLD = 0.85
 AMBIGUITY_MARGIN = 0.15
-NON_FOOD_REJECT_THRESHOLD = 0.25
+NON_FOOD_REJECT_THRESHOLD = 0.12
+FOOD_PRESENCE_REVIEW_THRESHOLD = 0.20
 UNCLEAR_SUGGESTION = "Please upload a clearer food image or confirm the dish manually."
 UNCLEAR_NUTRITION_SOURCE = "withheld_unclear_prediction"
 REJECTED_SUGGESTION = (
@@ -74,13 +75,29 @@ class ImagePipelineService:
         food_presence = self.food_presence_service.analyze(image_bytes)
         food_presence_enabled = bool(food_presence.get("enabled"))
         food_probability = float(food_presence.get("food_probability", 1.0))
-        hard_non_food = food_presence_enabled and food_probability < NON_FOOD_REJECT_THRESHOLD
+        people_scene_non_food = (
+            food_presence_enabled
+            and food_probability < FOOD_PRESENCE_REVIEW_THRESHOLD
+            and bool(quality.get("contains_people_scene", False))
+        )
+        hard_non_food = (
+            food_presence_enabled
+            and (
+                food_probability < NON_FOOD_REJECT_THRESHOLD
+                or people_scene_non_food
+            )
+        )
         food_presence_unclear = (
             food_presence_enabled
-            and food_probability < float(food_presence.get("threshold", 0.0))
+            and food_probability < FOOD_PRESENCE_REVIEW_THRESHOLD
         )
         if hard_non_food:
-            reason = str(food_presence.get("reason") or "Image does not appear to contain food.")
+            reason = str(
+                food_presence.get("reason")
+                or "Image does not appear to contain food."
+            )
+            if people_scene_non_food:
+                reason = "Image appears to show people or a non-food scene rather than a clear meal photo."
             quality_payload = self.quality_service.response_payload(quality)
             quality_payload["issues"] = list(quality_payload.get("issues", [])) + [reason]
             nutrition = self.nutrition_lookup.unavailable(None, source=REJECTED_NUTRITION_SOURCE)

--- a/nutrihelp_ai/services/image_quality.py
+++ b/nutrihelp_ai/services/image_quality.py
@@ -15,7 +15,8 @@ MIN_BRIGHTNESS = 35.0
 MAX_BRIGHTNESS = 235.0
 MIN_CONTRAST = 18.0
 MIN_SHARPNESS = 10.0
-MAX_FACE_AREA_RATIO = 0.08
+MAX_FACE_AREA_RATIO = 0.22
+PEOPLE_DETECTION_MIN_RATIO = 0.045
 SCREENSHOT_EDGE_RATIO = 0.18
 SCREENSHOT_LOW_SATURATION_RATIO = 0.45
 CARTOON_FLAT_REGION_RATIO = 0.58
@@ -95,8 +96,8 @@ class ImageQualityService:
         faces = classifier.detectMultiScale(
             gray,
             scaleFactor=1.1,
-            minNeighbors=5,
-            minSize=(60, 60),
+            minNeighbors=7,
+            minSize=(90, 90),
         )
         if len(faces) == 0:
             return False
@@ -104,6 +105,41 @@ class ImageQualityService:
         image_area = max(1, image.size[0] * image.size[1])
         largest_face_area = max(int(width) * int(height) for _, _, width, height in faces)
         return (largest_face_area / image_area) >= MAX_FACE_AREA_RATIO
+
+    def _contains_people_scene(self, image: Image.Image) -> bool:
+        if cv2 is None:
+            return False
+
+        rgb = np.array(image)
+        gray = cv2.cvtColor(rgb, cv2.COLOR_RGB2GRAY)
+        image_area = max(1, image.size[0] * image.size[1])
+        cascade_names = [
+            "haarcascade_frontalface_default.xml",
+            "haarcascade_profileface.xml",
+            "haarcascade_upperbody.xml",
+            "haarcascade_fullbody.xml",
+        ]
+
+        for cascade_name in cascade_names:
+            cascade_path = getattr(cv2.data, "haarcascades", "") + cascade_name
+            classifier = cv2.CascadeClassifier(cascade_path)
+            if classifier.empty():
+                continue
+
+            detections = classifier.detectMultiScale(
+                gray,
+                scaleFactor=1.08,
+                minNeighbors=5,
+                minSize=(48, 48),
+            )
+            if len(detections) == 0:
+                continue
+
+            largest_area = max(int(width) * int(height) for _, _, width, height in detections)
+            if (largest_area / image_area) >= PEOPLE_DETECTION_MIN_RATIO:
+                return True
+
+        return False
 
     def analyze(self, image_bytes: bytes) -> Dict[str, object]:
         if not image_bytes:
@@ -123,6 +159,7 @@ class ImageQualityService:
         edges = gray.filter(ImageFilter.FIND_EDGES)
         sharpness = round(float(ImageStat.Stat(edges).mean[0]), 2)
         contains_large_face = self._contains_large_face(image)
+        contains_people_scene = self._contains_people_scene(image)
         looks_like_screenshot = self._looks_like_screenshot(image, gray_array)
         looks_like_cartoon_or_portrait = self._looks_like_cartoon_or_portrait(image, gray_array)
 
@@ -147,9 +184,7 @@ class ImageQualityService:
         blocking_quality_issue = (
             min(width, height) < MIN_DIMENSION
             or sharpness < MIN_SHARPNESS
-            or contains_large_face
             or looks_like_screenshot
-            or looks_like_cartoon_or_portrait
         )
 
         return {
@@ -161,7 +196,8 @@ class ImageQualityService:
             "passed": not blocking_quality_issue,
             "issues": issues,
             "should_mark_unclear": blocking_quality_issue,
-            "should_reject_prediction": contains_large_face or looks_like_screenshot or looks_like_cartoon_or_portrait,
+            "should_reject_prediction": looks_like_screenshot,
+            "contains_people_scene": contains_people_scene,
         }
 
     def response_payload(self, analysis: Dict[str, object]) -> Dict[str, object]:

--- a/nutrihelp_ai/services/multi_image_pipeline.py
+++ b/nutrihelp_ai/services/multi_image_pipeline.py
@@ -10,9 +10,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 DEFAULT_TOPK = 5
-CONFIRMATION_THRESHOLD = 0.99
+CONFIRMATION_THRESHOLD = 0.85
 AMBIGUITY_MARGIN = 0.15
-NON_FOOD_REJECT_THRESHOLD = 0.25
+NON_FOOD_REJECT_THRESHOLD = 0.12
+FOOD_PRESENCE_REVIEW_THRESHOLD = 0.20
 UNCLEAR_SUGGESTION = "Please upload a clearer image."
 
 
@@ -70,13 +71,26 @@ class MultiImagePipelineService:
                 food_presence = self.food_presence_service.analyze(image_bytes)
                 food_presence_enabled = bool(food_presence.get("enabled"))
                 food_probability = float(food_presence.get("food_probability", 1.0))
-                hard_non_food = food_presence_enabled and food_probability < NON_FOOD_REJECT_THRESHOLD
+                people_scene_non_food = (
+                    food_presence_enabled
+                    and food_probability < FOOD_PRESENCE_REVIEW_THRESHOLD
+                    and bool(quality.get("contains_people_scene", False))
+                )
+                hard_non_food = (
+                    food_presence_enabled
+                    and (
+                        food_probability < NON_FOOD_REJECT_THRESHOLD
+                        or people_scene_non_food
+                    )
+                )
                 food_presence_unclear = (
                     food_presence_enabled
-                    and food_probability < float(food_presence.get("threshold", 0.0))
+                    and food_probability < FOOD_PRESENCE_REVIEW_THRESHOLD
                 )
                 if hard_non_food:
                     reason = str(food_presence.get("reason") or "Image does not appear to contain food.")
+                    if people_scene_non_food:
+                        reason = "Image appears to show people or a non-food scene rather than a clear meal photo."
                     quality_payload = self.quality_service.response_payload(quality)
                     quality_payload["issues"] = list(quality_payload.get("issues", [])) + [reason]
                     results.append(


### PR DESCRIPTION
## Summary
- Refined the image scan pipeline so unclear food images are sent to review instead of being treated as confirmed meals.
- Improved food/non-food handling for both single-image and multi-image scan flows.
- Added safer handling for people/non-food scenes while still allowing real food images with lower confidence to remain reviewable.
- Relaxed overly strict quality rejection so food images are not unnecessarily blocked when they can still be reviewed by the user.

## Testing
- .venv/bin/python -m py_compile nutrihelp_ai/services/image_pipeline.py nutrihelp_ai/services/image_quality.py nutrihelp_ai/services/multi_image_pipeline.py
